### PR TITLE
Add basic telemetry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ EtcdEx.get(MyApp.Etcd, "/foo", from_key: true)
 ```
 
 Check [the documentation](https://hexdocs.pm/etcdex) for other options.
+
+## Telemetry
+
+EtcdEx uses Telemetry to provide instrumentation. See the `EtcdEx.Telemetry`
+module for details on specific events.

--- a/lib/etcd_ex/telemetry.ex
+++ b/lib/etcd_ex/telemetry.ex
@@ -1,0 +1,111 @@
+defmodule EtcdEx.Telemetry do
+  @moduledoc """
+  EtcdEx telemetry integration.
+
+  All time measurements are in `:native` units.
+
+  EtcdEx executes following events:
+
+  ### Request start
+
+  `[:etcdex, :request, :start]` - Executed when sending a request to Etcd cluster.
+
+  #### Measurements
+
+    * `system_time` - The system time.
+
+  #### Metadata
+
+    * `request` - Type of the request.
+    * `args` - Arguments of the request.
+
+  ### Request stop
+
+  `[:etcdex, :request, :stop]` - Executed after receiving a response from Etcd cluster.
+
+  #### Measurements
+
+    * `duration` - Time taken from the request start event.
+
+  #### Metadata
+
+    * `request` - Type of the request.
+    * `args` - Arguments of the request.
+    * `result` - The result of the operation.
+
+  ### Connect start
+
+  `[:etcdex, :connect, :start]` - Executed before establishing connection to Etcd cluster.
+
+  #### Measurements
+
+    * `system_time` - The system time.
+
+  #### Metadata
+
+    * `scheme` - The scheme used in the connection.
+    * `address` - The host address of the Etcd cluster.
+    * `port` - The port of the Etcd cluster.
+
+  ### Connect stop
+
+  `[:etcdex, :connect, :stop]` - Executed when finished establishing connection (either successfully or not).
+
+  #### Measurements
+
+    * `duration` - Time take from the connect start event.
+
+  #### Metadata
+
+    * `scheme` - The scheme used in the connection.
+    * `address` - The host address of the Etcd cluster.
+    * `port` - The port of the Etcd cluster.
+    * `error` - Error message received when trying to establish the connection, set only on unsuccessful attempts.
+
+  ### Disconnect
+
+  `[:etcdex, :disconnect]` - Executed when disconnected from Etcd cluster.
+
+  #### Measurements
+
+  * `system_time` - The system time.
+
+  #### Metadata
+
+    * `scheme` - The scheme used in the connection.
+    * `address` - The host address of the Etcd cluster.
+    * `port` - The port of the Etcd cluster.
+    * `reason` - The disconnect reason.
+  """
+
+  @doc false
+  def start(event, meta \\ %{}, extra_measurements \\ %{}) do
+    start_time = System.monotonic_time()
+    measurements = Map.merge(extra_measurements, %{start_time: System.system_time()})
+
+    :telemetry.execute(
+      [:etcdex, event, :start],
+      measurements,
+      meta
+    )
+
+    start_time
+  end
+
+  @doc false
+  def stop(event, start_time, meta \\ %{}, extra_measurements \\ %{}) do
+    end_time = System.monotonic_time()
+    measurements = Map.merge(extra_measurements, %{duration: end_time - start_time})
+
+    :telemetry.execute(
+      [:etcdex, event, :stop],
+      measurements,
+      meta
+    )
+  end
+
+  @doc false
+  def event(event, meta, measurements) do
+    :telemetry.execute([:etcdex, event], measurements, meta)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule EtcdEx.MixProject do
       {:mint, "~> 1.0"},
       {:protobuf, "~> 0.10"},
       {:connection, "~> 1.1"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:stream_data, "~> 0.5", only: :test},
       {:excoveralls, "~> 0.10", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -20,5 +20,6 @@
   "protobuf": {:hex, :protobuf, "0.10.0", "4e8e3cf64c5be203b329f88bb8b916cb8d00fb3a12b2ac1f545463ae963c869f", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "4ae21a386142357aa3d31ccf5f7d290f03f3fa6f209755f6e87fc2c58c147893"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
Adding basic telemetry integration.

* `[:etcdex, :request, :start]` - Executed when sending a request to Etcd cluster.
* `[:etcdex, :request, :stop]` - Executed after receiving a response from Etcd cluster.
* `[:etcdex, :connect, :start]` - Executed before establishing connection to Etcd cluster.
* `[:etcdex, :connect, :stop]` Executed when finished establishing connection (either successfully or not).
* `[:etcdex, :disconnect]` - Executed when disconnected from Etcd cluster.

Still missing events related to watches.

