### PR TITLE
Send message to client process when watches fail to reconnect

### DIFF
--- a/lib/etcd_ex/watch_stream.ex
+++ b/lib/etcd_ex/watch_stream.ex
@@ -246,11 +246,10 @@ defmodule EtcdEx.WatchStream do
 
         case EtcdEx.Mint.watch(env, request_ref, key, opts) do
           {:ok, env} ->
-            {env, watch_stream}
+            {:ok, env, watch_stream}
 
           {:error, env, reason} ->
-            Logger.warn("error while reconnecting watches: #{inspect(reason)}")
-            {env, watch_stream}
+            {:error, env, reason}
         end
     end
   end


### PR DESCRIPTION
When etcd connection is reestablished after a disconnect, it attempts to also reconnect previously created watches. However when it fails, the client process is not aware of it.

This PR fixes it by sending generic `{:etcd_watch_error, reason}` message to the client process.